### PR TITLE
.setElement() cannot be removed, it needs to remain for backward compatibility

### DIFF
--- a/jupyter-js-widgets/src/widget_image.js
+++ b/jupyter-js-widgets/src/widget_image.js
@@ -23,8 +23,7 @@ var ImageView = widget.DOMWidgetView.extend({
          */
         var img = document.createElement('img');
         img.className = 'jupyter-widgets widget-image';
-        this.el.textContent = '';
-        this.el.appendChild(img);
+        this.setElement(img);
 
         this.update(); // Set defaults.
     },
@@ -37,21 +36,20 @@ var ImageView = widget.DOMWidgetView.extend({
          * changed by another view or by a state update from the back-end.
          */
         var image_src = 'data:image/' + this.model.get('format') + ';base64,' + this.model.get('_b64value');
-        var img = this.el.querySelector('img');
-        img.setAttribute('src', image_src);
+        this.el.setAttribute('src', image_src);
 
         var width = this.model.get('width');
         if (width !== undefined && width.length > 0) {
-            img.setAttribute('width', width);
+            this.el.setAttribute('width', width);
         } else {
-            img.removeAttribute('width');
+            this.el.removeAttribute('width');
         }
 
         var height = this.model.get('height');
         if (height !== undefined && height.length > 0) {
-            img.setAttribute('height', height);
+            this.el.setAttribute('height', height);
         } else {
-            img.removeAttribute('height');
+            this.el.removeAttribute('height');
         }
         return ImageView.__super__.update.apply(this);
     },


### PR DESCRIPTION
After talking with @jdfreder, it turns out that we need to keep `.setElement` in any views that currently use it. I've updated the Backbone Phosphor widget to be able to handle this scenario and re-added `.setElement` to this image widget that was using it.
