### PR TITLE
Bitwise operations only work below the 32-bit limit.

### DIFF
--- a/jupyter-js-widgets/src/widget_int.js
+++ b/jupyter-js-widgets/src/widget_int.js
@@ -356,10 +356,8 @@ var IntSliderView = widget.DOMWidgetView.extend({
         /**
          * Validate the value of the slider before sending it to the back-end
          * and applying it to the other views on the page.
-         *
-         * Double bit-wise not truncates the decimal (int cast).
          */
-        return ~~x;
+        return Math.floor(x);
     },
 });
 

--- a/jupyter-js-widgets/src/widget_selection.js
+++ b/jupyter-js-widgets/src/widget_selection.js
@@ -837,10 +837,8 @@ var SelectionSliderView = widget.DOMWidgetView.extend({
         /**
          * Validate the value of the slider before sending it to the back-end
          * and applying it to the other views on the page.
-         *
-         * Double bit-wise not truncates the decimal (int cast).
          */
-        return ~~x;
+        return Math.floor(x);
     },
 });
 


### PR DESCRIPTION
`Math.floor` is the appropriate function for floor.
